### PR TITLE
feat: added evm support in type_url_nibiru

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,88 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+This is a Rust workspace containing CosmWasm smart contracts for the Nibiru blockchain. The codebase uses Cargo workspaces to manage multiple contracts and utility packages.
+
+## Essential Commands
+
+### Building and Testing
+```bash
+# Install development tools
+just install
+
+# Compile all contracts to WASM
+just wasm-all
+
+# Run tests for all packages
+just test
+
+# Run tests for a specific package
+just test <package-name>
+
+# Generate test coverage report
+just test-coverage
+
+# Run a single test function
+cargo test --package <package-name> <test-function-name>
+```
+
+### Code Quality
+```bash
+# Format code
+just fmt
+
+# Run linter with fixes
+just clippy
+
+# Full code quality check (format, lint, wasm-check, test)
+just tidy
+
+# Validate WASM binaries for blockchain deployment
+just wasm-check
+```
+
+### Development Workflow
+```bash
+# Clean build artifacts
+just clean
+
+# Build all Rust code
+just build
+
+# Generate JSON schemas for contract interfaces
+just gen-schema
+```
+
+## Architecture
+
+### Project Structure
+- **contracts/** - Smart contracts implementing specific functionality (incentives, lockup, vesting, etc.)
+- **nibiru-std/** - Nibiru standard library providing proto types and bindings for Stargate messages
+- **packages/** - Utility packages including:
+  - `bash-rs` - Bash command execution from Rust
+  - `nibi-dev` - Development tooling
+  - `ownable` - Ownership patterns for contracts
+- **artifacts/** - Compiled WASM binaries
+- **schema/** - JSON schemas for contract interfaces
+
+### Key Patterns
+1. **CosmWasm Standards**: All contracts follow CosmWasm patterns with InstantiateMsg, ExecuteMsg, and QueryMsg
+2. **Stargate Messages**: Use `nibiru-std` for native Nibiru chain interactions via Stargate messages
+3. **Testing**: Integration tests use `cw-multi-test` framework, unit tests embedded in source files
+4. **Workspace Dependencies**: Shared dependencies defined in root Cargo.toml
+
+### Contract Development
+When creating new contracts:
+1. Follow existing contract structure (see contracts/lockup or contracts/incentives)
+2. Use `nibiru-std` for Nibiru-specific functionality
+3. Include comprehensive integration tests using `cw-multi-test`
+4. Generate schemas with `cargo schema` in the contract directory
+
+### Testing Approach
+- Unit tests: In-file with `#[cfg(test)]` modules
+- Integration tests: Separate `testing.rs` or `integration_tests.rs` files
+- Use `cw-multi-test::App` for simulating blockchain environment
+- Test coverage tracked with `cargo-llvm-cov`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1946,7 +1946,7 @@ dependencies = [
 
 [[package]]
 name = "nibiru-std"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema 2.0.2",

--- a/nibiru-std/Cargo.toml
+++ b/nibiru-std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nibiru-std"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Nibiru Chain standard library for CosmWasm smart contracts"
 authors = ["Unique Divine <realuniquedivine@gmail.com>"]


### PR DESCRIPTION
This pull request introduces significant updates to the repository, including the addition of a new documentation file for development workflows and enhancements to the `nibiru-std` library to support Ethereum Virtual Machine (EVM) interactions. Below are the most important changes grouped by theme:

### Documentation Updates:
- Added a new `CLAUDE.md` file to provide guidance for working with the repository. It includes an overview of the Rust workspace, essential commands for building, testing, and maintaining code quality, and architectural details about the project structure and key patterns.

### EVM Support in `nibiru-std`:
- Updated `nibiru-std/src/proto/type_url_nibiru.rs` to include support for EVM-related messages (`MsgEthereumTx`, `MsgUpdateParams`, `MsgCreateFunToken`, `MsgConvertCoinToEvm`) by defining their `Name` implementations and associating them with the new `PACKAGE_EVM`. [[1]](diffhunk://#diff-c2e0a2cff3e60c2c88d903ab9423746a944fcda2d4ad2956f2229a54ad9dac86R16) [[2]](diffhunk://#diff-c2e0a2cff3e60c2c88d903ab9423746a944fcda2d4ad2956f2229a54ad9dac86R389-R415)
- Added a new test case (`stargate_evm_msgs`) in the `tests` module to validate the correct type URLs for EVM-related messages when converted to Stargate messages.

### Code Enhancements:
- Modified imports in `nibiru-std/src/proto/type_url_nibiru.rs` to include the `eth` module, enabling the use of EVM-related definitions.